### PR TITLE
add step to save artifacts

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,3 +33,10 @@ jobs:
       uses: skjolber/maven-cache-github-action@v1
       with:
         step: save
+    - name: Archive production artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: store-build-artifacts
+        path: |
+          efa-main/target/*.zip
+          efa-main/target/*.jar


### PR DESCRIPTION
this addition to the ci configuration stores the artifacts of the last build:
- `efa-main-<version>-efa-dist.zip`
- `efa-main-<version>-jar-with-dependencies.jar`
- `efa-main-<version>.jar`

They are available on the page with the last run.