### PR TITLE
upgrade xmlgraphics-commons to 2.7

### DIFF
--- a/efa-parent/pom.xml
+++ b/efa-parent/pom.xml
@@ -145,7 +145,7 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>xmlgraphics-commons</artifactId>
-        <version>1.5</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>uk.me.jstott</groupId>


### PR DESCRIPTION
Upgrade xmlgraphics-commons in order to address vulnerability. No build errors, but also no tests, so I cannot say if this breaks anything.
@abfahr - bitte testen