### PR TITLE
Auslagerung der Properties - neuer Versuch

### DIFF
--- a/efa-dependencies/pom.xml
+++ b/efa-dependencies/pom.xml
@@ -6,11 +6,11 @@
 
   <groupId>de.overfreunde</groupId>
   <artifactId>efa-dependencies</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <parent>
     <groupId>de.overfreunde</groupId>
     <artifactId>efa-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../efa-parent</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/efa-help/pom.xml
+++ b/efa-help/pom.xml
@@ -6,11 +6,11 @@
 
   <groupId>de.overfreunde</groupId>
   <artifactId>efa-help</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <parent>
     <groupId>de.overfreunde</groupId>
     <artifactId>efa-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../efa-parent</relativePath>
   </parent>
   <packaging>jar</packaging>

--- a/efa-main/pom.xml
+++ b/efa-main/pom.xml
@@ -4,11 +4,11 @@
 
   <groupId>de.overfreunde</groupId>
   <artifactId>efa-main</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <parent>
     <groupId>de.overfreunde</groupId>
     <artifactId>efa-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../efa-parent</relativePath>
   </parent>
   <packaging>jar</packaging>
@@ -100,6 +100,21 @@
             </manifest>
           </archive>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>${project.build.outputDirectory}/properties-from-pom.properties</outputFile>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/efa-main/src/main/java/de/nmichael/efa/Daten.java
+++ b/efa-main/src/main/java/de/nmichael/efa/Daten.java
@@ -19,6 +19,7 @@ import java.net.NetworkInterface;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Enumeration;
+import java.util.Properties;
 import java.util.Vector;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -58,17 +59,48 @@ import org.apache.commons.io.IOUtils;
 // @i18n complete
 public class Daten {
 
-  // Version für die Ausgabe (z.B. 2.1.0, kann aber
-  // auch Zusätze wie "alpha" o.ä. enthalten)
-  public static final String VERSION = "2.2.0";
+  public final static String PROPERTY_FILE = "properties-from-pom.properties";
 
-  // VersionsID: Format: "X.Y.Z_MM";
-  // final-Version z.B. 1.4.0_00; beta-Version z.B. 1.4.0_#1
-  public static final String VERSIONID = "2.2.0_173";
-  public static final String VERSIONRELEASEDATE = "27.06.2022"; // Release Date: TT.MM.JJJJ
-  public static final String MAJORVERSION = "2";
-  public static final String PROGRAMMID = "EFA.220"; // Versions-ID für Wettbewerbsmeldungen
-  public static final String PROGRAMMID_DRV = "EFADRV.220"; // Versions-ID für Wettbewerbsmeldungen
+  private static Properties properties;
+
+  protected static Properties getProperties()
+  {
+    if(properties == null)
+    {
+      properties = new Properties();
+      Logger.log(Logger.INFO, Logger.MSG_GENERIC, "Reading property file ...");
+      try {
+        //properties.load(new FileInputStream(new File(PROPERTY_FILE)));
+        properties.load(Daten.class.getClassLoader().getResourceAsStream(PROPERTY_FILE));
+        Logger.log(Logger.INFO, Logger.MSG_GENERIC, "Property file has been read and parsed.");
+      } catch (IOException e) {
+        e.printStackTrace();
+        Logger.log(Logger.ERROR, Logger.MSG_GENERIC_ERROR, "Error during reading and parsing the property file:" + e.getMessage());
+      }
+    }
+    return properties;
+  }
+  public static String getVersion() {
+    return getProperties().getProperty("efa.version");
+  }
+  public static String getVersionId() {
+    return getProperties().getProperty("efa.versionId");
+  }
+  // Release Date: TT.MM.JJJJ
+  public static String getVersionReleaseDate() {
+    return getProperties().getProperty("efa.versionReleaseDate");
+  }
+  public static String getMajorVersion() {
+    return getProperties().getProperty("efa.majorVersion");
+  }
+  // Versions-ID für Wettbewerbsmeldungen
+  public static String getProgrammId() {
+    return getProperties().getProperty("efa.programmId");
+  }
+  public static String getProgrammIdDrv() {
+    return getProperties().getProperty("efa.programmIdDrv");
+  }
+
   public static final String COPYRIGHTYEAR = "14"; // aktuelles Jahr (Copyright (c)
   // 2001-COPYRIGHTYEAR)
 
@@ -380,20 +412,20 @@ public class Daten {
     if (exitCode != 0) {
       if (exitCode == HALT_SHELLRESTART || exitCode == HALT_JAVARESTART) {
         Logger.log(Logger.INFO, Logger.MSG_CORE_HALT,
-            International.getString("PROGRAMMENDE") + "  (Ver:" + VERSIONID + ")" + " (Exit Code "
+            International.getString("PROGRAMMENDE") + "  (Ver:" + getVersionId() + ")" + " (Exit Code "
                 + exitCode + ")");
       } else {
         if (applID != APPL_CLI) {
           Logger.log(Logger.INFO, Logger.MSG_CORE_HALT, getCurrentStack());
         }
         Logger.log(Logger.ERROR, Logger.MSG_CORE_HALT,
-            International.getString("PROGRAMMENDE") + "  (Ver:" + VERSIONID + ")" + " (Error Code "
+            International.getString("PROGRAMMENDE") + "  (Ver:" + getVersionId() + ")" + " (Error Code "
                 + exitCode + ")");
       }
     } else {
       Logger.log(Logger.INFO, Logger.MSG_CORE_HALT,
-          International.getString("PROGRAMMENDE") + "  (Ver:" + VERSIONID + " vom "
-              + VERSIONRELEASEDATE + ")");
+          International.getString("PROGRAMMENDE") + "  (Ver:" + getVersionId() + " vom "
+              + getVersionReleaseDate() + ")");
     }
     if (program != null) {
       program.exit(exitCode);
@@ -637,8 +669,8 @@ public class Daten {
     }
 
     Logger.log(Logger.INFO, Logger.MSG_EVT_EFASTART,
-        International.getString("PROGRAMMSTART") + " (Ver:" + VERSIONID + " vom "
-            + VERSIONRELEASEDATE + ")");
+        International.getString("PROGRAMMSTART") + " (Ver:" + getVersionId() + " vom "
+            + getVersionReleaseDate() + ")");
     Logger.log(Logger.INFO, Logger.MSG_INFO_VERSION,
         "Java " + javaVersion + " (JVM " + jvmVersion + ")"
             + " -- OS: " + osName + " " + osVersion);
@@ -1302,8 +1334,8 @@ public class Daten {
 
     // efa-Infos
     if (efaInfos) {
-      infos.add("efa.version=" + VERSIONID);
-      infos.add("efa.release.date=" + VERSIONRELEASEDATE);
+      infos.add("efa.version=" + getVersionId());
+      infos.add("efa.release.date=" + getVersionReleaseDate());
       if (EFALIVE_VERSION != null && EFALIVE_VERSION.length() > 0) {
         infos.add("efalive.version=" + EFALIVE_VERSION);
       }
@@ -1485,7 +1517,7 @@ public class Daten {
   }
 
   public static void checkRegister() {
-    if (PROGRAMMID.equals(efaConfig.getValueRegisteredProgramID())) {
+    if (getProgrammId().equals(efaConfig.getValueRegisteredProgramID())) {
       return; // already registered
     }
     efaConfig.setValueRegistrationChecks(efaConfig.getValueRegistrationChecks() + 1);
@@ -1510,7 +1542,7 @@ public class Daten {
           "file:" + HtmlFactory.createRegister(),
           850, 750).endsWith(".pl")) {
         // registration complete
-        efaConfig.setValueRegisteredProgramID(PROGRAMMID);
+        efaConfig.setValueRegisteredProgramID(getProgrammId());
         efaConfig.setValueRegistrationChecks(0);
       }
 

--- a/efa-main/src/main/java/de/nmichael/efa/Program.java
+++ b/efa-main/src/main/java/de/nmichael/efa/Program.java
@@ -45,7 +45,7 @@ public class Program {
       wrongArgument = null;
       showHelpDev = true;
     }
-    System.out.println(Daten.EFA_LONGNAME + " " + Daten.VERSION + " (" + Daten.VERSIONID + ")\n");
+    System.out.println(Daten.EFA_LONGNAME + " " + Daten.getVersion() + " (" + Daten.getVersionId() + ")\n");
     if (wrongArgument != null) {
       System.out.println("ERROR: Unknown Argument" + ": " + wrongArgument + "\n");
     }

--- a/efa-main/src/main/java/de/nmichael/efa/core/EmailSenderThread.java
+++ b/efa-main/src/main/java/de/nmichael/efa/core/EmailSenderThread.java
@@ -191,7 +191,7 @@ public class EmailSenderThread extends Thread {
       }
       com.sun.mail.smtp.SMTPMessage mail = new com.sun.mail.smtp.SMTPMessage(session);
       mail.setAllow8bitMIME(true);
-      mail.setHeader("X-Mailer", Daten.EFA_SHORTNAME + " " + Daten.VERSIONID);
+      mail.setHeader("X-Mailer", Daten.EFA_SHORTNAME + " " + Daten.getVersionId());
       mail.setHeader("Content-Type", "text/plain; charset=" + charset);
       mail.setFrom(new javax.mail.internet.InternetAddress(mailFromName + " <" + mailFromEmail
           + ">"));
@@ -268,7 +268,7 @@ public class EmailSenderThread extends Thread {
       }
       com.sun.mail.smtp.SMTPMessage mail = new com.sun.mail.smtp.SMTPMessage(session);
       mail.setAllow8bitMIME(true);
-      mail.setHeader("X-Mailer", Daten.EFA_SHORTNAME + " " + Daten.VERSIONID);
+      mail.setHeader("X-Mailer", Daten.EFA_SHORTNAME + " " + Daten.getVersionId());
       mail.setHeader("Content-Type", "text/plain; charset=" + charset);
       mail.setFrom(new javax.mail.internet.InternetAddress(mailFromName + " <" + mailFromEmail
           + ">"));

--- a/efa-main/src/main/java/de/nmichael/efa/core/OnlineUpdate.java
+++ b/efa-main/src/main/java/de/nmichael/efa/core/OnlineUpdate.java
@@ -84,13 +84,13 @@ public class OnlineUpdate {
 
     // ist die installierte Version aktuell?
     OnlineUpdateInfo newestVersion = versions.get(0); // first version is always newest one!
-    if (Daten.VERSIONID.equals(newestVersion.versionId) ||
-        Daten.VERSIONID.compareTo(newestVersion.versionId) > 0) {
+    if (Daten.getVersionId().equals(newestVersion.versionId) ||
+        Daten.getVersionId().compareTo(newestVersion.versionId) > 0) {
       if (parent != null) {
         Dialog.infoDialog(International
             .getString("Es liegt derzeit keine neuere Version von efa vor.") + "\n"
             + International.getMessage("Die von Dir benutzte Version {version} ist noch aktuell.",
-                Daten.VERSIONID));
+                Daten.getVersionId()));
       } else {
         lastError = International.getString("Es liegt derzeit keine neuere Version von efa vor.");
       }
@@ -102,7 +102,7 @@ public class OnlineUpdate {
     Vector<String> changes = new Vector<String>();
     for (int i = 0; i < versions.size(); i++) {
       OnlineUpdateInfo version = versions.get(i);
-      if (Daten.VERSIONID.compareTo(version.versionId) >= 0) {
+      if (Daten.getVersionId().compareTo(version.versionId) >= 0) {
         break;
       }
       Vector<String> moreChanges = version.getChanges();

--- a/efa-main/src/main/java/de/nmichael/efa/core/config/EfaBaseConfig.java
+++ b/efa-main/src/main/java/de/nmichael/efa/core/config/EfaBaseConfig.java
@@ -202,7 +202,7 @@ public class EfaBaseConfig {
       } else {
         f.write(FIELD_LANGUAGE + "=" + "\n");
       }
-      f.write(FIELD_VERSION + "=" + Daten.MAJORVERSION + "\n");
+      f.write(FIELD_VERSION + "=" + Daten.getMajorVersion() + "\n");
       f.close();
     } catch (Exception e) {
       Logger.log(e);

--- a/efa-main/src/main/java/de/nmichael/efa/data/storage/XMLFile.java
+++ b/efa-main/src/main/java/de/nmichael/efa/data/storage/XMLFile.java
@@ -122,7 +122,7 @@ public class XMLFile extends DataFile {
       write(data, xmltagStart(data, FIELD_GLOBAL));
       write(data, xmltagStart(data, FIELD_HEADER));
       write(data, xmltag(data, FIELD_HEADER_PROGRAM, Daten.EFA_SHORTNAME));
-      write(data, xmltag(data, FIELD_HEADER_VERSION, Daten.VERSIONID));
+      write(data, xmltag(data, FIELD_HEADER_VERSION, Daten.getVersionId()));
       write(data, xmltag(data, FIELD_HEADER_NAME, dataAccess.getStorageObjectName()));
       write(data, xmltag(data, FIELD_HEADER_TYPE, dataAccess.getStorageObjectType()));
       write(data, xmltag(data, FIELD_HEADER_SCN, Long.toString(dataAccess.getSCN())));

--- a/efa-main/src/main/java/de/nmichael/efa/drv/EfaDRVFrame.java
+++ b/efa-main/src/main/java/de/nmichael/efa/drv/EfaDRVFrame.java
@@ -201,7 +201,7 @@ public class EfaDRVFrame extends JFrame {
         beendenButton_actionPerformed(e);
       }
     });
-    versionLabel.setText("Version " + Daten.VERSION + " (" + Daten.VERSIONID + ")");
+    versionLabel.setText("Version " + Daten.getVersion() + " (" + Daten.getVersionId() + ")");
     meldungenWSButton.setEnabled(false);
     meldungenWSButton.setNextFocusableComponent(administrationButton);
     meldungenWSButton.setMnemonic('W');

--- a/efa-main/src/main/java/de/nmichael/efa/drv/MeldungEditFrame.java
+++ b/efa-main/src/main/java/de/nmichael/efa/drv/MeldungEditFrame.java
@@ -336,7 +336,7 @@ public class MeldungEditFrame extends JDialog implements ActionListener {
       calcOverallValues();
       setMFields(0, false);
 
-      if (ew.allg_programm != null && ew.allg_programm.equals(Daten.PROGRAMMID_DRV)
+      if (ew.allg_programm != null && ew.allg_programm.equals(Daten.getProgrammIdDrv())
           && (ew.verein_name == null || ew.verein_name.length() == 0)) {
         vBlock(false);
         mBlock(true);

--- a/efa-main/src/main/java/de/nmichael/efa/drv/MeldungenIndexFrame.java
+++ b/efa-main/src/main/java/de/nmichael/efa/drv/MeldungenIndexFrame.java
@@ -1862,7 +1862,7 @@ public class MeldungenIndexFrame extends JDialog implements ActionListener {
           return;
         }
       }
-      efw.allg_programm = Daten.PROGRAMMID_DRV;
+      efw.allg_programm = Daten.getProgrammIdDrv();
       efw.allg_wett = WETTID;
       efw.allg_wettjahr = Integer.toString(Main.drvConfig.aktJahr);
       efw.kennung = EfaWett.EFAWETT;

--- a/efa-main/src/main/java/de/nmichael/efa/elwiz/Main.java
+++ b/efa-main/src/main/java/de/nmichael/efa/elwiz/Main.java
@@ -19,7 +19,7 @@ import de.nmichael.efa.util.Dialog;
 // @i18n complete
 public class Main extends Program {
 
-  public static final String ELWIZ_VERSION = Daten.VERSION; // Version
+  public static final String ELWIZ_VERSION = Daten.getVersion(); // Version
 
   public Main(String[] args) {
     super(Daten.APPL_ELWIZ, args);

--- a/efa-main/src/main/java/de/nmichael/efa/emil/Main.java
+++ b/efa-main/src/main/java/de/nmichael/efa/emil/Main.java
@@ -20,7 +20,7 @@ import de.nmichael.efa.util.Dialog;
 
 public class Main extends Program {
 
-  public static final String EMIL_VERSION = Daten.VERSION; // Version
+  public static final String EMIL_VERSION = Daten.getVersion(); // Version
   public static final String EMIL_KENNUNG = "EMIL.198";
 
   public Main(String[] args) {

--- a/efa-main/src/main/java/de/nmichael/efa/gui/EfaAboutDialog.java
+++ b/efa-main/src/main/java/de/nmichael/efa/gui/EfaAboutDialog.java
@@ -222,8 +222,8 @@ public class EfaAboutDialog extends BaseDialog {
     languagePanel.add(jScrollPane3, BorderLayout.CENTER);
     jScrollPane3.getViewport().add(languages, null);
     mainPanel.add(tabbedPane, BorderLayout.CENTER);
-    versionLabel.setText(International.getString("Version") + " " + Daten.VERSION + "   ("
-        + Daten.VERSIONID + ") vom " + Daten.VERSIONRELEASEDATE);
+    versionLabel.setText(International.getString("Version") + " " + Daten.getVersion() + "   ("
+        + Daten.getVersionId() + ") vom " + Daten.getVersionReleaseDate());
     Vector infos = Daten.getEfaInfos();
     for (int i = 0; infos != null && i < infos.size(); i++) {
       efaInfos.append((String) infos.get(i) + "\n");

--- a/efa-main/src/main/java/de/nmichael/efa/gui/EfaFirstSetupDialog.java
+++ b/efa-main/src/main/java/de/nmichael/efa/gui/EfaFirstSetupDialog.java
@@ -172,7 +172,7 @@ public class EfaFirstSetupDialog extends StepwiseDialog {
     ((ItemTypeLabel) item).setHorizontalAlignment(SwingConstants.CENTER);
     item.setFieldGrid(-1, GridBagConstants.CENTER, GridBagConstants.HORIZONTAL);
     items.add(item = new ItemTypeLabel("VERSION", IItemType.TYPE_PUBLIC, "0", International
-        .getString("Version") + " " + Daten.VERSION));
+        .getString("Version") + " " + Daten.getVersion()));
     ((ItemTypeLabel) item).setHorizontalAlignment(SwingConstants.CENTER);
     item.setFieldGrid(-1, GridBagConstants.CENTER, GridBagConstants.HORIZONTAL);
 

--- a/efa-main/src/main/java/de/nmichael/efa/gui/OnlineUpdateDialog.java
+++ b/efa-main/src/main/java/de/nmichael/efa/gui/OnlineUpdateDialog.java
@@ -79,7 +79,7 @@ public class OnlineUpdateDialog extends BaseDialog {
     JLabel currentVersionLabel = new JLabel();
     currentVersionLabel.setText(International.getString("installierte Version") + ": ");
     JLabel currentVersionValue = new JLabel();
-    currentVersionValue.setText(Daten.VERSIONID + " (" + Daten.VERSIONRELEASEDATE + ")");
+    currentVersionValue.setText(Daten.getVersionId() + " (" + Daten.getVersionReleaseDate() + ")");
     JLabel newVersionLabel = new JLabel();
     newVersionLabel.setText(International.getString("verfügbare Version") + ": ");
     JLabel newVersionValue = new JLabel();

--- a/efa-main/src/main/java/de/nmichael/efa/statistics/Competition.java
+++ b/efa-main/src/main/java/de/nmichael/efa/statistics/Competition.java
@@ -104,7 +104,7 @@ public abstract class Competition {
     WettDef wett = Daten.wettDefs.getWettDef(wettId, sr.sCompYear);
     efaWett = new EfaWett();
     efaWett.wettId = wettId;
-    efaWett.allg_programm = Daten.PROGRAMMID;
+    efaWett.allg_programm = Daten.getProgrammId();
     if (wett.von.jahr == wett.bis.jahr) {
       efaWett.allg_wettjahr = Integer.toString(sr.sCompYear + wett.von.jahr);
     } else {

--- a/efa-main/src/main/java/de/nmichael/efa/statistics/StatisticTask.java
+++ b/efa-main/src/main/java/de/nmichael/efa/statistics/StatisticTask.java
@@ -1918,7 +1918,7 @@ public class StatisticTask extends ProgressTask {
     }
     sr.pStatCreationDate = EfaUtil.getCurrentTimeStampDD_MM_YYYY();
     sr.pStatCreatedByUrl = Daten.EFAURL;
-    sr.pStatCreatedByName = Daten.EFA_LONGNAME + " " + Daten.VERSION;
+    sr.pStatCreatedByName = Daten.EFA_LONGNAME + " " + Daten.getVersion();
     sr.pStatDescription = statDescrLong;
     sr.pStatDateRange = sr.sStartDate.toString() + " - " + sr.sEndDate.toString();
     sr.pStatFilter = sr.getFilterCriteriaAsStringDescription();

--- a/efa-main/src/main/java/de/nmichael/efa/util/HtmlFactory.java
+++ b/efa-main/src/main/java/de/nmichael/efa/util/HtmlFactory.java
@@ -134,18 +134,18 @@ public class HtmlFactory {
       f.write("<input type=\"hidden\" name=\"reply_clubdata\" value=\""
           + International.getString("Deine Daten werden überprüft und demnächst aktualisiert.")
           + "\">\n");
-      f.write("<input type=\"hidden\" name=\"subject\" value=\"User efa - " + Daten.VERSIONID
+      f.write("<input type=\"hidden\" name=\"subject\" value=\"User efa - " + Daten.getVersionId()
           + "\">\n");
       f.write("<input type=\"hidden\" name=\"addUserList\" value=\"yes\">\n");
-      f.write("<input type=\"hidden\" name=\"efa.version\" value=\"" + Daten.VERSIONID + "\">\n");
+      f.write("<input type=\"hidden\" name=\"efa.version\" value=\"" + Daten.getVersionId() + "\">\n");
       if (Daten.EFALIVE_VERSION != null) {
         f.write("<input type=\"hidden\" name=\"efalive.version\" value=\"" + Daten.EFALIVE_VERSION
             + "\">\n");
       }
-      if (Daten.VERSIONID.compareTo("1.9.9") < 0) {
+      if (Daten.getVersionId().compareTo("1.9.9") < 0) {
         f.write("<input name=\"useEfa1\" type=\"hidden\" value=\"yes\"/>\n");
       }
-      if (Daten.VERSIONID.compareTo("1.9.9") >= 0) {
+      if (Daten.getVersionId().compareTo("1.9.9") >= 0) {
         f.write("<input name=\"useEfa2\" type=\"hidden\" value=\"yes\"/>\n");
       }
       if (Daten.EFALIVE_VERSION != null) {

--- a/efa-main/src/main/java/de/nmichael/efa/util/PropertiesReader.java
+++ b/efa-main/src/main/java/de/nmichael/efa/util/PropertiesReader.java
@@ -1,0 +1,20 @@
+package de.nmichael.efa.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesReader {
+  private Properties properties;
+
+  public PropertiesReader(String propertyFileName) throws IOException {
+    InputStream is = getClass().getClassLoader()
+        .getResourceAsStream(propertyFileName);
+    this.properties = new Properties();
+    this.properties.load(is);
+  }
+
+  public String getProperty(String propertyName) {
+    return this.properties.getProperty(propertyName);
+  }
+}

--- a/efa-main/src/main/java/de/nmichael/efa/util/XMLChecker.java
+++ b/efa-main/src/main/java/de/nmichael/efa/util/XMLChecker.java
@@ -87,7 +87,7 @@ public class XMLChecker extends DefaultHandler {
   }
 
   static void printHelp() {
-    System.out.println("XMLChecker " + Daten.VERSION + ", (c) 2002-" + Daten.COPYRIGHTYEAR
+    System.out.println("XMLChecker " + Daten.getVersion() + ", (c) 2002-" + Daten.COPYRIGHTYEAR
         + " by Nicolas Michael (" + Daten.EFAURL + ")");
     System.out.println("XMLChecker is based on the Xerces XML parser.");
     System.out

--- a/efa-main/src/main/java/de/nmichael/efa/util/XMLTransformer.java
+++ b/efa-main/src/main/java/de/nmichael/efa/util/XMLTransformer.java
@@ -22,7 +22,7 @@ import de.nmichael.efa.Daten;
 public class XMLTransformer {
 
   static void printHelp() {
-    System.out.println("XMLTransformer " + Daten.VERSION + ", (c) 2002-" + Daten.COPYRIGHTYEAR
+    System.out.println("XMLTransformer " + Daten.getVersion() + ", (c) 2002-" + Daten.COPYRIGHTYEAR
         + " by Nicolas Michael (" + Daten.EFAURL + ")");
     System.out
     .println("XMLTransformer is based on the Xerces XML parser and the Xalan XSLT processor.");

--- a/efa-parent/pom.xml
+++ b/efa-parent/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>de.overfreunde</groupId>
   <artifactId>efa-parent</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <modules>
     <module>../efa-dependencies</module>
     <module>../efa-help</module>
@@ -16,6 +16,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>11</java.version>
+    <efa.version>${project.version}</efa.version>
+    <efa.versionId>${efa.version}_173</efa.versionId>
+    <efa.versionReleaseDate>27.06.2022</efa.versionReleaseDate>
+    <efa.majorVersion>2</efa.majorVersion>
+    <efa.programmId>EFA.220</efa.programmId>
+    <efa.programmIdDrv>EFADRV.220</efa.programmIdDrv>
   </properties>
   <repositories>
     <repository>
@@ -35,6 +41,15 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>properties-maven-plugin</artifactId>
+          <version>1.1.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <dependencyManagement>
@@ -42,7 +57,7 @@
       <dependency>
         <groupId>de.overfreunde</groupId>
         <artifactId>efa-help</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.sun.mail</groupId>


### PR DESCRIPTION
# Auslagerung der Properties - neuer Versuch

Closes #10 

## Motivation

Die Ablage der Properties in einer Javaklasse ist nicht optimal. Stattdessen sollten die benötigten Informationen aus einer Propertiesdatei kommen, die einfach erstellt bzw. angepasst werden kann

## Änderungen durch diesen PR

Durch diesen PR werden die Properties, die sich potentiell zwischen Versionen ändern können ausgelagert. Da es sich um ein Mavenprojekt handelt sind sie direkt in die POM des Elternprojekts (efa-parent) übertragen worden.