### PR TITLE
NullPointerException & Sortierung von Booten im Reservierungsdialog

### DIFF
--- a/efa-main/src/main/java/de/nmichael/efa/core/items/ItemTypeList.java
+++ b/efa-main/src/main/java/de/nmichael/efa/core/items/ItemTypeList.java
@@ -27,9 +27,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.ImageIcon;
@@ -48,6 +46,8 @@ import de.nmichael.efa.gui.BaseDialog;
 import de.nmichael.efa.gui.util.EfaMouseListener;
 import de.nmichael.efa.util.Dialog;
 import de.nmichael.efa.util.Mnemonics;
+import java.util.Collections;
+import java.util.Comparator;
 
 public class ItemTypeList<T> extends ItemType implements ActionListener {
 
@@ -158,6 +158,16 @@ public class ItemTypeList<T> extends ItemType implements ActionListener {
     this.category = category;
     this.description = description;
     data = new Vector<ItemTypeListData>();
+  }
+
+  public void sortAlphabetically( ) {
+    // Nachdem die Liste vdata erstellt wurde, sortiere sie alphabetisch nach text
+    Collections.sort(data, new Comparator<ItemTypeListData>() {
+      @Override
+      public int compare(ItemTypeListData item1, ItemTypeListData item2) {
+        return item1.toString().compareToIgnoreCase(item2.toString());
+      }
+    });
   }
 
   @Override

--- a/efa-main/src/main/java/de/nmichael/efa/data/storage/MetaData.java
+++ b/efa-main/src/main/java/de/nmichael/efa/data/storage/MetaData.java
@@ -34,8 +34,13 @@ public class MetaData {
     this.dataType = dataType;
   }
 
-  public static MetaData constructMetaData(String dataType, Vector<String> fields,
+  public static synchronized MetaData constructMetaData(String dataType, Vector<String> fields,
       Vector<Integer> types, boolean versionized) {
+
+    if (dataType == null || fields == null || types == null || fields.size() != types.size()) {
+      throw new IllegalArgumentException("Invalid parameters for constructing MetaData");
+    }
+
     MetaData m = metaData.get(dataType);
     if (m != null) {
       metaData.remove(dataType);

--- a/efa-main/src/main/java/de/nmichael/efa/gui/ReserveAdditionalsDialog.java
+++ b/efa-main/src/main/java/de/nmichael/efa/gui/ReserveAdditionalsDialog.java
@@ -280,6 +280,7 @@ public class ReserveAdditionalsDialog extends BaseDialog{
                         for (IItemType boat :filteredList) {
                             itemsOfGroupList.addItem(boat.getName(), boat, true, '\0');
                         }
+                        itemsOfGroupList.sortAlphabetically();
                         itemsOfGroupList.requestFocus();
                     }
                 });
@@ -384,7 +385,7 @@ public class ReserveAdditionalsDialog extends BaseDialog{
                     source.removeAllItems();
                 }
             }
-
+            itemsOfGroupList.sortAlphabetically();  //werden die Elemente entfernt, sollen sie geordnet angezeigt werden
             updateOkSaveButtonText(itemType.getName()); // buttonPressed
             if (target == null){
                 target.requestFocus();


### PR DESCRIPTION
Eine voraussichtlicher FIX der NullPointerException: der Verdacht ist, dass die Static-Erzeuger Methode aufgrund mehrerer konkurrierender Zugriffe aus verschiedenen Threads bei der nächtlichen Log-Bearbeitung eine Nullpointer in der Hashmap für die MetaDatas anfällig ist. In Folge kommt es dann zu einer NullPointer beim temporären entfernen des gespeicherten MetaData Objects in dieser HashMap.